### PR TITLE
Improve question formulation in immuable_vs_nonmodifiable.md

### DIFF
--- a/pages/week3/immuable_vs_nonmodifiable.md
+++ b/pages/week3/immuable_vs_nonmodifiable.md
@@ -8,14 +8,14 @@ On définit les 2 classes suivantes :
 class A {...}
 final class B extends A {...}
 ```
-Soit le code suivant :
+
+Et le code suivant :
 ```java
 A a = new B();
 someMysteriousFunction(a);
 ```
-`someMysteriousFunction` est une fonction inconnue, la seule chose qu'on sait sur elle est qu'**elle n'utilise pas de transtypage (aka "cast")**. On sait qu'avant et après l'appel de la fonction `someMysteriousFunction`, `a` n'est pas changé (c'est-à-dire que ses attributs n'ont pas été modifiés).
 
-Quelle proposition est toujours vraie **peu importe l'implémentation de la fonction** `someMysteriousFunction` ? En d'autres termes, quelle proposition reste vraie pour toutes les possibles implémentations imaginables de `someMysteriousFunction` ?
+Sachant qu'il n'existe aucune implémentation possible de `someMysteriousFunction` qui **n'utilise pas de transtypage (aka "cast")** tel que le code ci-dessus modifie `a`, quelle proposition est vraie ?
 Choisissez la proposition la plus complète.
 
 A. La classe `A` est immuable


### PR DESCRIPTION
Hello,

je regardais un peu par curiosité ton site, et je pense que cette question était mal formulé.
En effet, en disant "On sait qu’avant et après l’appel de la fonction `someMysteriousFunction`, `a` n’est pas changé." tu formule une assomption qui à priori devrait restreindre les implémentations possible de `someMysteriousFunction` alors que ce que tu semble vouloir c'est en réalité restreindre les implémentation possible de A (/B).

Je te laisse ci-joint une suggestion de formulation alternative plus courte qui selon moi est plus clair.